### PR TITLE
Fix close handshake, maximum frame sizes and ping response

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $
 
 ```nginx
 
-websocket out_queue=[num] message_length=[num] ping_interval=[time] timeout=[time];
+websocket out_queue=[num] message_length=[num] frame_length=[num] ping_interval=[time] timeout=[time];
 
 ```
 

--- a/nginx_test/README.md
+++ b/nginx_test/README.md
@@ -1,0 +1,28 @@
+# Nginx Test
+## Browser-based Integration Test for Nginx Websocket
+
+This test exercises the websocket logic using the websocket client implementation native to modern browsers.
+In the test, we start an instance of Nginx with the websocket echo module loaded, then navigate using any
+modern browser to a web page containing javascript code that connects to that websocket and validates
+correct operation
+
+### Quick Start for Linux using Bash shell
+Since there are many ways that the websocket modules could be compiled, this is less quick that we'd like.
+* Create a working directory - replace ${MY_HOME_OR_LOCAL_SCRATCH} with an appropriate directory:
+> cd ${MY_HOME_OR_LOCAL_SCRATCH}<br>
+> mkdir nginx_temp<br>
+> cd nginx_temp
+* Copy test files into working directory
+> cp ${PATH_TO_NGINX_WEBSOCKET_GIT_REPO}/nginx-test/* .
+* Symlink websocket modules into working directory (you could also copy, but symlinks mean you pick up changes following fixes)
+> ln -s ${PATH_TO_BUILD_OUTPUT}/ngx_websocket_echo_module.so .<br>
+> ln -s ${PATH_TO_BUILD_OUTPUT}/ngx_websocket_module.so .
+* Run Nginx
+> ${PATH_TO_NGINX}/nginx -p $(pwd) -c websocket_test.conf
+* If the execution fails because of missing shared object dependencies (e.g. zlib, pcre, openssl), add paths to these dependencies to LD_LIBRARY_PATH and rerun.
+
+### Run the test
+* New open a browser and enter the URL of the test HTML page. For a browser running on the same host as Nginx
+> http://localhost:8220/test_websocket.html
+* If accessing remotely then replace localhost with the name of the host where Nginx is running.
+* The output of the test is shown in the browser. Scroll down if necessary to confirm that all tests are green.

--- a/nginx_test/README.md
+++ b/nginx_test/README.md
@@ -15,8 +15,9 @@ Since there are many ways that the websocket modules could be compiled, this is 
 * Copy test files into working directory
 > cp ${PATH_TO_NGINX_WEBSOCKET_GIT_REPO}/nginx-test/* .
 * Symlink websocket modules into working directory (you could also copy, but symlinks mean you pick up changes following fixes)
-> ln -s ${PATH_TO_BUILD_OUTPUT}/ngx_websocket_echo_module.so .<br>
-> ln -s ${PATH_TO_BUILD_OUTPUT}/ngx_websocket_module.so .
+> ln -s ${PATH_TO_MODULES}/ngx_websocket_echo_module.so .<br>
+> ln -s ${PATH_TO_MODULES}/ngx_websocket_module.so .
+> ln -s ${PATH_TO_NGINX_CONF}/mime.types .
 * Run Nginx
 > ${PATH_TO_NGINX}/nginx -p $(pwd) -c websocket_test.conf
 * If the execution fails because of missing shared object dependencies (e.g. zlib, pcre, openssl), add paths to these dependencies to LD_LIBRARY_PATH and rerun.

--- a/nginx_test/test_websocket.html
+++ b/nginx_test/test_websocket.html
@@ -171,7 +171,6 @@
       // TODO fix test with repeat set to 255
       echoTest( "Payload just short of max size request/response", "0123456789ABCDEF".repeat(128) + "0123456789A", 8 ), // just less than 4Kb - the configured buffer size
 
-      // TODO fix test with disconnect error set to 1009
       [ function(inst) { inst.expectDisconnect( 1009 ); return inst.send( "0123456789ABCDEF".repeat(257)); } ],  // just over 4Kb - expect disconnect with 'too large' error
     ) );
 

--- a/nginx_test/test_websocket.html
+++ b/nginx_test/test_websocket.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+
+<meta charset="utf-8" />
+
+<title>WebSocket Test</title>
+
+<script language="javascript" type="text/javascript">
+
+  var wsUrl = "ws://" + window.location.host + "/";
+  var output;
+  var websocket;
+
+  // This 'fixture' knows how to connect to our server (the same server that is
+  // serving out this static content), how to send messages to that server
+  // and how to asynchronously return results to the test script
+  class ServerConnectionTestSteps {
+    #connected = false;
+    #invokeNext = null;
+    #success = true;
+    #name = "Server Connection Test"
+    #uri = "";
+    #waiting = false;
+    #received = [];
+    #ws = null;
+    #expectedDisconnect = 1000;
+
+    // Constructor takes a list of test steps: functions that should be executed
+    // in order before closing the websocket connection
+    constructor(name, uri, calls ) {
+      this.#uri = uri;
+      this.#name = name;
+
+      // wrap test calls in setup/teardown logic
+      this.calls = [ function(inst) { inst.connect(); return true; } ];
+      this.calls = this.calls.concat( calls );
+      this.calls = this.calls.concat( [
+        function(inst) { inst.teardown(); return true; },
+        function(inst) { inst.postValidate(); return true; }
+      ] );
+    }
+
+    setup() {
+        this.connect();
+    }
+
+    teardown() {
+        this.#ws.close(1000);
+    }
+
+    postValidate() {
+      this.doAssert( "Pending calls, or messages",
+        self.calls.length == 1 && !self.#received.length? null: (
+          ( self.calls.length != 1? ("Not all calls completed - " + self.calls.length + " pending. "): "" ) +
+          ( self.#received.length? (self.#received.length.toString() + " unused response(s)"): "" )
+        )
+      );
+    }
+
+    expectDisconnect( code ) {
+      this.#expectedDisconnect = code;
+    }
+
+    // Initiate connection to the server. After connection has been established
+    // the code will execute each of the test steps passed in the 'calls'
+    connect() {
+      self = this;
+      this.#ws = new WebSocket(wsUrl + this.#uri);
+      this.#ws.onopen = function(evt) {
+        self.#connected = true;
+        self.#doNext()
+      };
+      this.#ws.onclose = function(evt) {
+        self.#connected = false;
+
+        self.doAssert( "Connection closed with response code " + evt.code + (evt.wasClean? " (clean)": " (bad)"),
+          evt.wasClean || evt.code === self.#expectedDisconnect? null: "unexpected shutdown" )
+        self.#doNext();
+      };
+      this.#ws.onmessage = function(evt) {
+        self.#received.push(evt.data);
+        self.#doNext();
+      };
+      this.#ws.onerror = function(evt) {
+        this.doAssert("Error received", "'" + evt.data + "'");
+      };
+      this.#expectedDisconnect = 1000;
+    }
+
+    execute() {
+      writeToScreen('<span style="color: blue; weigth: bold;">' + this.#name + '</span>');
+      this.#doNext();
+
+      return this;
+    }
+
+    andThen(invokeNext) {
+      this.#invokeNext = invokeNext;
+    }
+
+    // try to execute the next step in the test
+    #doNext() {
+      if (!this.calls.length) {
+        this.doAssert( this.#name + ": test completed", this.#success? null: "One or more errors reported above" )
+        if (this.#invokeNext)
+          this.#invokeNext();
+
+        return;
+      }
+
+      while(this.calls.length) {
+        if (!this.calls[0](this))
+          break;
+        this.calls.shift();
+      }
+    }
+
+    send(what) {
+      if( !this.#connected || this.#waiting)
+        return false;
+
+      this.#ws.send(what);
+      self = this;
+
+      // yield to event loop after sending - and prevent another immediate send
+      // by setting '#waiting' flag
+      this.#waiting = true;
+      setTimeout( function() { self.#waiting = false; self.#doNext(); }, 1 );
+
+      return true;
+    }
+
+    doAssert(doc, failMsgOrNull)
+    {
+      if (!failMsgOrNull)
+        writeToScreen('<span style="color: green;">' + doc + ' - Success</span>');
+      else
+        writeToScreen('<span style="color: red;">' + doc + ' - Failure. ' + failMsgOrNull + '"</span>');
+    }
+
+    assertReceived(doc, predicate) {
+      if (!this.#connected || !this.#received.length)
+        return false;
+
+      predicate(this.#received.shift());
+
+      return true;
+    }
+  }
+
+  function setupSuite()
+  {
+    output = document.getElementById("output");
+
+    // A couple of simple tests - simple request/responses
+    simpleTests = new ServerConnectionTestSteps( "Simple tests", "echo", [].concat(
+      echoTest( "Simple request/response", "Short test message" ),
+      echoTest( "Multiple request/responses", "Test message with idx", 16 ),
+    ) );
+
+    // Test a large payload just less than the maximum to confirm that it gets split into
+    // smaller frames
+    veryLargePayloadTest = new ServerConnectionTestSteps( "Very large payload test", "echo", [].concat(
+      // TODO fix test with repeat set to 63000
+      echoTest( "Large payload request/response", "0123456789ABCDEF".repeat(630/*00*/) ), // almost as big as the 1024,000 buffer size
+    ) );
+
+    // Test payload size limit:
+    // - first test fills the 4Kb buffer of the 'echo_small_buffer' URI
+    // - second test exceeds the buffer size and we are expecting an error
+    payloadSizeLimitTests = new ServerConnectionTestSteps( "Payload size limit tests", "echo_small_buffer", [].concat(
+      // TODO fix test with repeat set to 255
+      echoTest( "Payload just short of max size request/response", "0123456789ABCDEF".repeat(128) + "0123456789A", 8 ), // just less than 4Kb - the configured buffer size
+
+      // TODO fix test with disconnect error set to 1009
+      [ function(inst) { inst.expectDisconnect( 1009 ); return inst.send( "0123456789ABCDEF".repeat(257)); } ],  // just over 4Kb - expect disconnect with 'too large' error
+    ) );
+
+    // Run tests in sequence
+    simpleTests.execute().andThen( function() {
+      veryLargePayloadTest.execute().andThen( function() {
+        payloadSizeLimitTests.execute();
+      } );
+    } );
+  }
+
+  function echoTest(doc, msg, count=1 ) {
+    sends = [];
+    asserts = [];
+    for(i=0; i<count; ++i) {
+      const idx = count <= 1? "": (" " + (i+1).toString() );
+      const msgWithIdx = msg + idx;
+      sends.push( function(inst) { return inst.send(msgWithIdx); } );
+      asserts.push( function(inst) { return inst.assertReceived(doc, function(received) {
+        inst.doAssert(doc + idx + ' echo received', msgWithIdx === received? null: 'expected: "' + msgWithIdx + '" != "' + received + '"');
+      } ) } );
+    }
+    return sends.concat(asserts);
+  }
+
+  function writeToScreen(message)
+  {
+    var pre = document.createElement("p");
+    pre.style.wordWrap = "break-word";
+    pre.innerHTML = message;
+    output.appendChild(pre);
+  }
+
+  window.addEventListener("load", setupSuite, false);
+
+</script>
+
+<h2>WebSocket Test</h2>
+
+<div id="output"></div>
+
+</html>

--- a/nginx_test/websocket_test.conf
+++ b/nginx_test/websocket_test.conf
@@ -1,0 +1,43 @@
+load_module ngx_websocket_module.so;
+load_module ngx_websocket_echo_module.so;
+
+worker_processes 1;
+
+error_log  logs/error.log debug;
+pid        logs/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+    sendfile        on;
+    keepalive_timeout  65;
+
+    access_log  logs/access.log;
+
+    client_body_temp_path temp;
+    proxy_temp_path temp;
+    fastcgi_temp_path temp;
+    uwsgi_temp_path temp;
+    scgi_temp_path temp;
+
+    server {
+        listen       8220;
+        server_name  localhost;
+
+        root .;
+
+        location /echo_small_buffer {
+            websocket out_queue=512 message_length=4096 ping_interval=5000ms timeout=600s;
+            websocket_echo;
+        }
+
+        location /echo {
+            websocket out_queue=512 message_length=1024000 ping_interval=5000ms timeout=600s;
+            websocket_echo;
+        }
+    }
+}

--- a/nginx_test/websocket_test.conf
+++ b/nginx_test/websocket_test.conf
@@ -36,7 +36,7 @@ http {
         }
 
         location /echo {
-            websocket out_queue=512 message_length=1024000 ping_interval=5000ms timeout=600s;
+            websocket out_queue=512 message_length=1024000 frame_length=4095 ping_interval=5000ms timeout=600s;
             websocket_echo;
         }
     }

--- a/ngx_websocket.h
+++ b/ngx_websocket.h
@@ -8,6 +8,7 @@
 #ifndef __NGX_WEBSOCKET_H_INCLUDE__
 #define __NGX_WEBSOCKET_H_INCLUDE__
 
+#include <ngx_config.h>
 #include <openssl/crypto.h>
 #include <openssl/sha.h>
 #include <ngx_config.h>
@@ -72,6 +73,7 @@ struct ngx_websocket_session_s {
     ngx_msec_t                             ping_interval;
     ngx_msec_t                             timeout;
     ngx_msec_t                             last_recv;
+    ngx_uint_t                             close_status;
     ngx_chain_t                          **out;
     ngx_uint_t                             out_last;
     ngx_uint_t                             out_pos;
@@ -89,6 +91,7 @@ struct ngx_websocket_loc_conf_s {
     ngx_websocket_connect_handler_pt    connect_handler;
     ngx_uint_t                          out_queue;
     ngx_uint_t                          max_length;
+    ngx_uint_t                          max_frame_length;
     ngx_chain_t                        *in_free;
     ngx_pool_t                         *pool;
     ngx_msec_t                          ping_interval;


### PR DESCRIPTION
This merge request implements a few fixes to get the javascript/html test to pass.
* Add logic to implement the close handshake as specified here https://datatracker.ietf.org/doc/html/rfc6455#section-1.4
* Add logic to permit messages to be broken into smaller frames (javascript client has a hard max-frame limit of 64k)
* The 'pong' response to a 'ping' call should echo back the message body
